### PR TITLE
Support mounting external volume for executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ To access HDFS from zeppelin you need to provide the files `hdfs-site.xml` and `
 }
 ```
 
+### External executor volume
+
+Set the list of volumes which will be mounted into the Docker image, which was set using spark.mesos.executor.docker.image. The format of this property is a comma-separated list of mappings following the form passed to docker run -v. Define an `ENV` variable
+
+```
+SPARK_MESOS_EXECUTOR_DOCKER_VOLUMES="[host_path:]container_path[:ro|:rw]"
+```
+e.g.:
+```
+SPARK_MESOS_EXECUTOR_DOCKER_VOLUMES="/mnt/share/data:/data:rw"
+```
+
+
 ### Extra configuration
 You can provide your own custom zeppelin-site.xml:
 1. Create your custom zeppelin-site.xml

--- a/docker/zeppelin-env.sh
+++ b/docker/zeppelin-env.sh
@@ -21,5 +21,10 @@ if [ -n "${SPARK_EXECUTOR_CORES}" ]; then
   export ZEPPELIN_INTP_JAVA_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dspark.executor.cores=${SPARK_EXECUTOR_CORES}"
 fi
 
+if [ -n "${SPARK_MESOS_EXECUTOR_DOCKER_VOLUMES}" ]; then
+  export ZEPPELIN_JAVA_OPTS="${ZEPPELIN_JAVA_OPTS} -Dspark.mesos.executor.docker.volumes=${SPARK_MESOS_EXECUTOR_DOCKER_VOLUMES}"
+  export ZEPPELIN_INTP_JAVA_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dspark.mesos.executor.docker.volumes=${SPARK_MESOS_EXECUTOR_DOCKER_VOLUMES}"
+fi
+
 export MASTER=mesos://zk://master.mesos:2181/mesos
 export MESOS_NATIVE_LIBRARY=/usr/lib/libmesos.so


### PR DESCRIPTION
Add possibility to mount an volume in executor, as it is [described in Spark docs](https://spark.apache.org/docs/2.1.0/running-on-mesos.html#spark-properties).